### PR TITLE
Make curlCommandBuilder local to ensure thread safety

### DIFF
--- a/library/src/main/java/com/grapesnberries/curllogger/CurlLoggerInterceptor.java
+++ b/library/src/main/java/com/grapesnberries/curllogger/CurlLoggerInterceptor.java
@@ -15,7 +15,6 @@ import okio.Buffer;
  * Created by mohamedzakaria on 2/4/16.
  */
 public class CurlLoggerInterceptor implements Interceptor {
-    private StringBuilder curlCommandBuilder;
     private final Charset UTF8 = Charset.forName("UTF-8");
     private String tag = null;
 
@@ -35,6 +34,7 @@ public class CurlLoggerInterceptor implements Interceptor {
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
 
+        StringBuilder curlCommandBuilder;
         curlCommandBuilder = new StringBuilder("");
         // add cURL command
         curlCommandBuilder.append("cURL ");
@@ -43,7 +43,7 @@ public class CurlLoggerInterceptor implements Interceptor {
         curlCommandBuilder.append(request.method().toUpperCase() + " ");
         // adding headers
         for (String headerName : request.headers().names()) {
-            addHeader(headerName, request.headers().get(headerName));
+            addHeader(curlCommandBuilder, headerName, request.headers().get(headerName));
         }
 
         // adding request body
@@ -54,7 +54,7 @@ public class CurlLoggerInterceptor implements Interceptor {
             Charset charset = UTF8;
             MediaType contentType = requestBody.contentType();
             if (contentType != null) {
-                addHeader("Content-Type", request.body().contentType().toString());
+                addHeader(curlCommandBuilder, "Content-Type", request.body().contentType().toString());
                 charset = contentType.charset(UTF8);
                 curlCommandBuilder.append(" -d '" + buffer.readString(charset) + "'");
             }
@@ -68,7 +68,7 @@ public class CurlLoggerInterceptor implements Interceptor {
         return chain.proceed(request);
     }
 
-    private void addHeader(String headerName, String headerValue) {
+    private void addHeader(StringBuilder curlCommandBuilder, String headerName, String headerValue) {
         curlCommandBuilder.append("-H " + "\"" + headerName + ": " + headerValue + "\" ");
     }
 }


### PR DESCRIPTION
Fixes a concurrent access to `curlCommandBuilder` issue, see https://github.com/grapesnberries/Curl-Logger-interceptor/issues/3